### PR TITLE
Support TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ Usage:
 	-l: log access requests
 	-hport: the port on which /health and /ready endpoints should be served
 	-r	log request/response headers
+	-tls-cert string
+		path to a TLS certificate
+	-tls-key string
+		path to the key of the TLS certificate
 	-v: verbose logging (e.g. when handling error 404)
-Ports, directories and error404 flags can be specified multiple times,
-but need to be specified the same amount of times.
+	    Ports, directories and error404 flags can be specified multiple times,
+	    but need to be specified the same amount of times.
 ```
 
 Static-serve does not show directory listings, it only serves files.
@@ -22,7 +26,8 @@ out of the box:
 * caching headers
 * range requests
 
+It's possible to serve over TLS by  specifying both --tls-cert and --tls-key file paths.
+
 Not supported:
-* Serving over TLS
 * Dynamic pages (e.g. templating, changing response body, ...).
   It's called static-serve for a reason 😉

--- a/tls.go
+++ b/tls.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"crypto/tls"
+	"log"
+)
+
+func loadTlsConfig(verbose bool, tlsCertFlag string, tlsKeyFlag string) *tls.Config {
+	if tlsCertFlag == "" && tlsKeyFlag == "" {
+		return nil
+	}
+	if tlsCertFlag == "" {
+		log.Fatal("Path to TLS key file ist set. Path to certificate file is required, but missing.")
+	}
+	if tlsKeyFlag == "" {
+		log.Fatal("Path to TLS certificate file ist set. Path to certificate key file is required, but missing.")
+	}
+	cert, err := tls.LoadX509KeyPair(tlsCertFlag, tlsKeyFlag)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return &tls.Config{Certificates: []tls.Certificate{cert}}
+}


### PR DESCRIPTION
Added flags:
* `-tls-cert`
* `-tls-key`
Setting both will make `static-serve` listen on TLS using the certificate and key provided in the files of these parameters.
